### PR TITLE
Allow higher versions of kunstmaan-extra-bundle be required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "syzygypl/kunstmaan-feature-switches-bundle",
   "require": {
-    "arsthanea/kunstmaan-extra-bundle": "^1.0"
+    "arsthanea/kunstmaan-extra-bundle": ">=1.0"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
**PURPOSE**
--
During upgrades to higher version of `kunstmaan/cms-bundles` `syzygypl/kunstmaan-feature-switches-bundle` was working fine but composer was detecting mismatched requirements.

**TODO**
--
- [x] update `composer.json`